### PR TITLE
Feat/SideBar in NewIssue page

### DIFF
--- a/FE/src/components/NewIssueForm/SideBar/SideBarItem/index.tsx
+++ b/FE/src/components/NewIssueForm/SideBar/SideBarItem/index.tsx
@@ -1,0 +1,84 @@
+import { useRecoilValue } from 'recoil';
+
+import * as S from './style';
+
+import DropDown from '@/components/common/DropDown';
+import { detailsMenuListType } from '@/components/common/DropDown/type';
+import Label from '@/components/common/Label';
+import ProgressBar from '@/components/common/ProgressBar';
+import UserProfile from '@/components/common/UserProfile';
+import { sideBarState } from '@/stores/atoms/sideBar';
+import { Assignee } from '@/types/issueTypes';
+import { ILabel } from '@/types/labelTypes';
+import { MilestoneType } from '@/types/milestoneTypes';
+
+type ContentsType = string | Assignee[] | ILabel[] | MilestoneType[];
+
+type SideBarItemProps = {
+  title: string;
+  defaultContents: string | ContentsType;
+  detailsMenuList: detailsMenuListType;
+  checkType: 'radio' | 'checkBox';
+};
+
+const SideBarContents = ({ title, contents }) => {
+  if (typeof contents === 'string') {
+    return <S.Contents>{contents}</S.Contents>;
+  }
+
+  switch (title) {
+    case 'Assignees':
+      return contents.map(({ id, userId, image }) => (
+        <S.Assignee key={id}>
+          <UserProfile userId={userId} imgUrl={image} size="small" />
+          {userId}
+        </S.Assignee>
+      ));
+    case 'Labels':
+      return (
+        <S.LabelContainer>
+          {contents.map(({ id, title, backgroundColor, textColor }) => (
+            <Label
+              key={id}
+              size="small"
+              backgroundColor={backgroundColor}
+              textColor={textColor}
+              title={title}
+            />
+          ))}
+        </S.LabelContainer>
+      );
+    case 'Milestone':
+      return (
+        <ProgressBar
+          size="small"
+          title={contents[0].title}
+          openIssueCount={contents[0].openIssueCount}
+          closedIssueCount={contents[0].closedIssueCount}
+        />
+      );
+    default:
+      throw new Error('Invalid title for SideBar');
+  }
+};
+
+const SideBarItem = ({ title, defaultContents, detailsMenuList, checkType }: SideBarItemProps) => {
+  const sideBarContents = useRecoilValue(sideBarState);
+  console.log(sideBarContents);
+  const contents = sideBarContents[title].length > 0 ? sideBarContents[title] : defaultContents;
+
+  return (
+    <S.SideBarItemContainer>
+      <DropDown
+        indicatorType="setting"
+        indicatorTitle={title}
+        menuPosition="right"
+        detailsMenuList={detailsMenuList}
+        hasCheckBox
+        checkType={checkType}
+      />
+      <SideBarContents title={title} contents={contents} />
+    </S.SideBarItemContainer>
+  );
+};
+export default SideBarItem;

--- a/FE/src/components/NewIssueForm/SideBar/SideBarItem/style.ts
+++ b/FE/src/components/NewIssueForm/SideBar/SideBarItem/style.ts
@@ -1,0 +1,39 @@
+import styled from 'styled-components';
+
+import { FlexStart } from '@/styles/common';
+import { FONT_MIXIN, mixins } from '@/styles/mixins';
+
+const SideBarItemContainer = styled.div`
+  width: 100%;
+  border-bottom: 1px solid ${({ theme: { color } }) => color.inputBg};
+  color: ${({ theme: { color } }) => color.lightText};
+  padding-bottom: 20px;
+`;
+
+const Contents = styled.div`
+  width: 100%;
+  ${FONT_MIXIN.xSmall(400)}
+`;
+
+const Assignee = styled.div`
+  ${mixins.flexBox({ justifyContent: 'flex-start' })}
+  ${FONT_MIXIN.xSmall(700)}
+
+  & > :first-child {
+    margin-right: 10px;
+  }
+
+  & > * {
+    margin-bottom: 10px;
+  }
+`;
+
+const LabelContainer = styled(FlexStart)`
+  flex-wrap: wrap;
+  & > * {
+    margin-right: 5px;
+    margin-bottom: 5px;
+  }
+`;
+
+export { SideBarItemContainer, Contents, Assignee, LabelContainer };

--- a/FE/src/components/NewIssueForm/SideBar/index.tsx
+++ b/FE/src/components/NewIssueForm/SideBar/index.tsx
@@ -1,0 +1,24 @@
+import SideBarItem from './SideBarItem';
+import * as S from './style';
+
+import { initialSideBarData } from '@/constants/sideBar';
+
+const SideBar = () => {
+  return (
+    <S.SideBarContainer>
+      <S.SideBarList>
+        {initialSideBarData.map(({ defaultContents, list }) => (
+          <SideBarItem
+            key={list.indicator}
+            title={list.indicator}
+            defaultContents={defaultContents}
+            detailsMenuList={list}
+            checkType={list.indicator === 'Milestone' ? 'radio' : 'checkBox'}
+          />
+        ))}
+      </S.SideBarList>
+    </S.SideBarContainer>
+  );
+};
+
+export default SideBar;

--- a/FE/src/components/NewIssueForm/SideBar/style.ts
+++ b/FE/src/components/NewIssueForm/SideBar/style.ts
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+
+import { mixins } from '@/styles/mixins';
+
+const SideBarContainer = styled.div`
+  ${mixins.flexBox({ direction: 'column' })}
+  border-radius: 16px;
+  width: 300px;
+`;
+
+const SideBarList = styled.ul`
+  width: 100%;
+`;
+
+const TitleWrapper = styled.li`
+  ${mixins.flexBox({ justifyContent: 'space-between' })}
+  width: 100%;
+  padding: 20px 0;
+  cursor: pointer;
+
+  :hover > * {
+    color: ${({ theme: { color } }) => color.primary[200]};
+  }
+`;
+
+const Title = styled.div``;
+
+export { SideBarContainer, SideBarList, TitleWrapper, Title };

--- a/FE/src/components/NewIssueForm/index.tsx
+++ b/FE/src/components/NewIssueForm/index.tsx
@@ -1,0 +1,78 @@
+import { useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useRecoilValue, useRecoilState } from 'recoil';
+
+import SideBar from './SideBar';
+import * as S from './style';
+
+import { postIssue } from '@/apis/issueApi';
+import Button from '@/components/common/Button';
+import Input from '@/components/common/Input';
+import TextArea from '@/components/common/TextArea';
+import UserProfile from '@/components/common/UserProfile';
+import useButtonDisable from '@/hooks/useButtonDisable';
+import { sideBarState, sideBarInitialState } from '@/stores/atoms/sideBar';
+import { userState } from '@/stores/atoms/user';
+
+const NewIssueForm = () => {
+  const userData = useRecoilValue(userState);
+  const titleRef = useRef<HTMLInputElement>(null);
+  const commentRef = useRef<HTMLTextAreaElement>(null);
+  const navigate = useNavigate();
+  const { isButtonDisabled, handleInputChange } = useButtonDisable();
+  const [sideBar, setSideBar] = useRecoilState(sideBarState);
+
+  // TODO: never type
+  const handleSubmit = () => {
+    const issueData = {
+      title: titleRef.current?.value,
+      content: commentRef.current?.value,
+      assignees: sideBar.Assignees,
+      labels: sideBar.Labels,
+      milestones: sideBar.Milestone,
+    };
+
+    postIssue(issueData);
+    setSideBar(sideBarInitialState);
+    navigate('/');
+  };
+
+  const handleCancel = () => {
+    navigate(-1);
+    setSideBar(sideBarInitialState);
+  };
+
+  return (
+    <S.NewIssueForm>
+      <S.FlexWrapper>
+        <UserProfile imgUrl={userData?.profileImageUrl} userId={userData?.name} size="large" />
+        <S.CommentWrapper>
+          <Input
+            name="title"
+            placeholder="Title"
+            inputStyle="medium"
+            title="Title"
+            type="text"
+            ref={titleRef}
+            onChange={handleInputChange}
+          />
+          <TextArea name="comment" usage="comment" ref={commentRef} />
+          <S.ButtonWrapper>
+            <Button size="medium" color="grey" text="Cancel" type="button" onClick={handleCancel} />
+            <Button
+              size="medium"
+              color="primary"
+              text="Submit new issue"
+              type="button"
+              onClick={handleSubmit}
+              disabled={isButtonDisabled}
+            />
+          </S.ButtonWrapper>
+        </S.CommentWrapper>
+      </S.FlexWrapper>
+      <SideBar />
+    </S.NewIssueForm>
+  );
+};
+
+export default NewIssueForm;

--- a/FE/src/components/NewIssueForm/style.ts
+++ b/FE/src/components/NewIssueForm/style.ts
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+
+import { FlexEnd } from '@/styles/common';
+import { mixins } from '@/styles/mixins';
+
+const FlexStartStyle = `
+${mixins.flexBox({ alignItems: 'flex-start' })}
+width: 100%;
+`;
+
+const FlexWrapper = styled.div`
+  ${FlexStartStyle}
+  gap: 20px;
+`;
+
+const NewIssueForm = styled.form`
+  ${FlexStartStyle}
+  gap: 40px;
+`;
+
+const CommentWrapper = styled.div`
+  ${mixins.flexBox({ direction: 'column', alignItems: 'flex-end' })}
+  width: 100%;
+  gap: 15px;
+`;
+
+const ButtonWrapper = styled(FlexEnd)`
+  & > :last-child {
+    margin-left: 10px;
+  }
+`;
+
+export { FlexWrapper, NewIssueForm, CommentWrapper, ButtonWrapper };

--- a/FE/src/components/common/DropDown/index.tsx
+++ b/FE/src/components/common/DropDown/index.tsx
@@ -1,11 +1,9 @@
-import { useState } from 'react';
-
 import DetailsMenu from './DetailsMenu';
 import * as S from './style';
 
 import { DropDownProps } from '@/components/common/DropDown/type';
-import { INDICATOR } from '@/constants/constants';
-import ArrowIcon from '@/icons/DropDownArrow';
+import Loading from '@/components/common/Loading';
+import useDropDown from '@/hooks/useDropDown';
 import SettingIcon from '@/icons/Setting';
 
 const DropDown = ({
@@ -16,38 +14,30 @@ const DropDown = ({
   hasCheckBox,
   checkType,
 }: DropDownProps) => {
-  const [hasBefore, setHasBefore] = useState(false);
-
-  const handleDropDownClick = () => {
-    if (hasBefore) {
-      setHasBefore(false);
-    } else {
-      setHasBefore(true);
-    }
-  };
+  const { isBackgroundClickable, isOpen, handleDropDownClick, dropdownData, isLoading } =
+    useDropDown(detailsMenuList.api);
 
   return (
-    <S.DropDown onClick={handleDropDownClick}>
-      <S.Indicator indicatorType={indicatorType} hasBefore={hasBefore}>
-        {indicatorType === INDICATOR.setting ? (
-          <S.TitleWrapper>
-            <S.Title>{indicatorTitle}</S.Title>
-            <SettingIcon />
-          </S.TitleWrapper>
-        ) : (
-          <>
-            {indicatorTitle}
-            <ArrowIcon />
-          </>
-        )}
+    <S.DropDown open={isOpen} onClick={handleDropDownClick}>
+      <S.Indicator indicatorType={indicatorType} hasBefore={isBackgroundClickable}>
+        <S.TitleWrapper>
+          <S.Title>{indicatorTitle}</S.Title>
+          <SettingIcon />
+        </S.TitleWrapper>
       </S.Indicator>
-      <DetailsMenu
-        indicatorType={indicatorType}
-        menuPosition={menuPosition}
-        detailsMenuList={detailsMenuList}
-        hasCheckBox={hasCheckBox}
-        checkType={checkType}
-      />
+      {isLoading ? (
+        <Loading />
+      ) : (
+        <DetailsMenu
+          title={detailsMenuList.title}
+          indicatorTitle={indicatorTitle}
+          indicatorType={indicatorType}
+          menuPosition={menuPosition}
+          detailsMenuList={dropdownData}
+          hasCheckBox={hasCheckBox}
+          checkType={checkType}
+        />
+      )}
     </S.DropDown>
   );
 };

--- a/FE/src/constants/sideBar.ts
+++ b/FE/src/constants/sideBar.ts
@@ -1,0 +1,33 @@
+import { API } from '@/constants/api';
+
+const assingeeList = {
+  indicator: 'Assignees',
+  title: 'Assign up to 10 people to this issue',
+  api: API.ASSIGNEES,
+};
+
+const labelList = {
+  indicator: 'Labels',
+  title: 'Apply labels to this issue',
+  api: API.LABELS,
+};
+
+const milestoneList = {
+  indicator: 'Milestone',
+  title: 'Set milestone',
+  api: API.MILESTONES,
+};
+
+export const getSideBarData = (assignees, labels, milestone) => {
+  return [
+    { defaultContents: 'No one', list: assingeeList, contents: assignees },
+    { defaultContents: 'None yet', list: labelList, contents: labels },
+    { defaultContents: 'No Milestone', list: milestoneList, contents: milestone },
+  ];
+};
+
+export const initialSideBarData = [
+  { defaultContents: 'No one', list: assingeeList },
+  { defaultContents: 'None yet', list: labelList },
+  { defaultContents: 'No Milestone', list: milestoneList },
+];

--- a/FE/src/hooks/useButtonDisable.tsx
+++ b/FE/src/hooks/useButtonDisable.tsx
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+
+const useButtonDisable = () => {
+  const [isButtonDisabled, setIsButtonDisabled] = useState(true);
+
+  const handleInputChange = ({ target }) => {
+    if (target.value) {
+      setIsButtonDisabled(false);
+    } else {
+      setIsButtonDisabled(true);
+    }
+  };
+
+  return { isButtonDisabled, handleInputChange };
+};
+
+export default useButtonDisable;

--- a/FE/src/mocks/Assignees/index.ts
+++ b/FE/src/mocks/Assignees/index.ts
@@ -7,6 +7,13 @@ const issueHandler = [
   rest.get(`/${API.PREFIX}/${API.ASSIGNEES}`, (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(mockAssignees));
   }),
+
+  rest.get(`/${API.PREFIX}/${API.ASSIGNEES}/:id`, (req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json(mockAssignees.filter(v => v.id === Number(req.params.id))),
+    );
+  }),
 ];
 
 export default issueHandler;

--- a/FE/src/mocks/Issues/data.ts
+++ b/FE/src/mocks/Issues/data.ts
@@ -1,16 +1,16 @@
 export const mockIssues = {
-  openIssueCount: 4,
+  openIssueCount: 5,
   closedIssueCount: 3,
   issues: [
     {
       id: 1,
-      issueTitle: 'Implement Home page',
+      title: 'Implement Home page',
       author: 'J',
       createdAt: '2022-07-29 17:55:02',
       image: 'https://avatars.githubusercontent.com/u/68211156?s=40&v=4',
       commentCount: 2,
       content: 'Build a development environment using webpack',
-      milestone: [
+      milestones: [
         {
           id: 2,
           title: '[FE] Week 2',
@@ -87,13 +87,13 @@ export const mockIssues = {
     },
     {
       id: 2,
-      issueTitle: 'Implement NewIssue page UI',
+      title: 'Implement NewIssue page UI',
       author: 'Millie',
       createdAt: '2022-06-23 02:33:02',
       image: 'https://avatars.githubusercontent.com/u/85419343?s=80&v=4',
       commentCount: 2,
       content: 'NewIssue page UI',
-      milestone: [
+      milestones: [
         {
           id: 2,
           title: '[FE] Week 2',
@@ -147,13 +147,13 @@ export const mockIssues = {
     },
     {
       id: 3,
-      issueTitle: 'Common components',
+      title: 'Common components',
       author: 'J',
       createdAt: '2022-06-23 02:33:02',
       image: 'https://avatars.githubusercontent.com/u/85419343?s=80&v=4',
       commentCount: 0,
       content: 'Common components',
-      milestone: [
+      milestones: [
         {
           id: 2,
           title: '[FE] Week 2',
@@ -193,13 +193,13 @@ export const mockIssues = {
     },
     {
       id: 4,
-      issueTitle: 'Implement Login',
+      title: 'Implement Login',
       author: 'Millie',
       createdAt: '2022-06-23 02:33:02',
       image: 'https://avatars.githubusercontent.com/u/85419343?s=80&v=4',
       commentCount: 0,
       content: 'User can login with Github account',
-      milestone: [
+      milestones: [
         {
           id: 2,
           title: '[FE] Week 2',
@@ -237,14 +237,14 @@ export const mockIssues = {
     },
     {
       id: 5,
-      issueTitle: 'Refactoring Issue List',
+      title: 'Refactoring Issue List',
       author: 'Millie',
       createdAt: '2022-06-30 02:33:02',
       image: 'https://avatars.githubusercontent.com/u/85419343?s=80&v=4',
       commentCount: 0,
       comments: [],
       content: 'Refactoring Issue List',
-      milestone: [
+      milestones: [
         {
           id: 2,
           title: '[FE] Week 2',
@@ -277,7 +277,7 @@ export const mockIssues = {
     {
       id: 6,
       author: 'Millie',
-      issueTitle: 'Webpack configuration',
+      title: 'Webpack configuration',
       issueStatus: 'open',
       createdAt: '2022-06-23 02:33:02',
       image: 'https://avatars.githubusercontent.com/u/85419343?s=80&v=4',
@@ -322,7 +322,7 @@ export const mockIssues = {
           description: 'Development environment settings',
         },
       ],
-      milestone: [
+      milestones: [
         {
           id: 2,
           title: '[FE] Week 2',
@@ -337,14 +337,14 @@ export const mockIssues = {
     },
     {
       id: 7,
-      issueTitle: 'Swagger Documentation - API Doc',
+      title: 'Swagger Documentation - API Doc',
       author: 'Tany',
       createdAt: '2022-07-30 02:33:02',
       image: 'https://avatars.githubusercontent.com/u/79444040?v=4',
       commentCount: 0,
       comments: [],
       content: 'Write a documment using Swagger',
-      milestone: [
+      milestones: [
         {
           id: 2,
           title: '[FE] Week 2',
@@ -389,14 +389,14 @@ export const mockIssues = {
     },
     {
       id: 8,
-      issueTitle: 'Swagger Documentation - API Doc',
+      title: 'Swagger Documentation - API Doc',
       author: 'Tany',
       createdAt: '2022-07-30 02:33:02',
       image: 'https://avatars.githubusercontent.com/u/79444040?v=4',
       commentCount: 0,
       comments: [],
       content: 'Write a documment using Swagger',
-      milestone: [],
+      milestones: [],
       labels: [],
       assignees: [],
       issueStatus: 'open',

--- a/FE/src/mocks/Issues/utils.ts
+++ b/FE/src/mocks/Issues/utils.ts
@@ -55,3 +55,15 @@ export const filterIssues = (queryString: string, issues) => {
       : filterByStatus(ISSUE_STATUS.open, filteredByQueries);
   return filteredByStatus;
 };
+
+export const filterBySearchWord = searchWord => {
+  console.log(searchWord);
+};
+
+export const filterOpenIssues = issues => {
+  return issues.filter(issue => issue.issueStatus === 'open');
+};
+
+export const filterClosedIssues = issues => {
+  return issues.filter(issue => issue.issueStatus === 'closed');
+};

--- a/FE/src/mocks/Labels/index.ts
+++ b/FE/src/mocks/Labels/index.ts
@@ -29,8 +29,16 @@ const patchLabel = (req, res, ctx) => {
   return res(ctx.status(204));
 };
 
+const getLabel = (req, res, ctx) => {
+  return res(
+    ctx.status(200),
+    ctx.json(mockLabels.labels.filter(label => label.id === Number(req.params.id))),
+  );
+};
+
 const labelsHandler = [
   rest.get(`/${API.PREFIX}/${API.LABELS}`, getLabels),
+  rest.get(`/${API.PREFIX}/${API.LABELS}/:id`, getLabel),
   rest.delete(`/${API.PREFIX}/${API.LABELS}/:id`, deleteLabel),
   rest.post(`/${API.PREFIX}/${API.LABELS}`, postLabel),
   rest.patch(`/${API.PREFIX}/${API.LABELS}/:id`, patchLabel),

--- a/FE/src/mocks/Milestones/utils.ts
+++ b/FE/src/mocks/Milestones/utils.ts
@@ -1,6 +1,7 @@
 import { MilestoneType } from '@/types/milestoneTypes';
 
 export const filterMilestones = (queryString: string, milestones: MilestoneType[]) => {
+  if (!queryString) return milestones;
   const searchParams = new URLSearchParams(queryString);
   const currentState = searchParams.get('params');
   return milestones.filter(m => m.milestoneStatus === currentState);

--- a/FE/src/stores/atoms/sideBar.ts
+++ b/FE/src/stores/atoms/sideBar.ts
@@ -1,0 +1,12 @@
+import { atom } from 'recoil';
+
+export const sideBarInitialState = {
+  Assignees: [],
+  Labels: [],
+  Milestone: [],
+};
+
+export const sideBarState = atom({
+  key: 'sideBarState',
+  default: sideBarInitialState,
+});

--- a/FE/src/utils/dropdown.ts
+++ b/FE/src/utils/dropdown.ts
@@ -1,13 +1,23 @@
-type UniformMenuType = 'author' | 'assignee' | 'label' | 'milestone';
+type UniformMenuType =
+  | 'author'
+  | 'assignee'
+  | 'label'
+  | 'milestone'
+  | 'Assignees'
+  | 'Labels'
+  | 'Milestone';
 
 export const getUniformMenus = (type: UniformMenuType, list: any) => {
   switch (type) {
     case 'author':
     case 'assignee':
+    case 'Assignees':
       return list.map(v => ({ ...v, name: v.userId }));
     case 'label':
+    case 'Labels':
       return list.labels.map(v => ({ ...v, name: v.title }));
     case 'milestone':
+    case 'Milestone':
       return list.milestones.map(v => ({ ...v, name: v.title }));
     default:
       throw Error('Invaild menu type');


### PR DESCRIPTION
NewIssue 페이지에서의 Sidebar 기능 구현 
- 전역상태로 assignees, labels, milestone을 저장하여 화면에 그려줄 수 있도록 함 
- mockdata의 post 함수 수정하여 이슈 생성 가능 