### PR TITLE
[geombong/issue-tracker#226] Fix: addMultiLabelSearch

### DIFF
--- a/BE/src/main/java/team20/issuetracker/domain/issue/IssueRepositoryCustom.java
+++ b/BE/src/main/java/team20/issuetracker/domain/issue/IssueRepositoryCustom.java
@@ -2,10 +2,9 @@ package team20.issuetracker.domain.issue;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-
-import java.util.Map;
+import org.springframework.util.MultiValueMap;
 
 public interface IssueRepositoryCustom {
 
-    Page<Issue> findAllIssuesByCondition(Map<String, String> conditionMap, PageRequest pageRequest);
+    Page<Issue> findAllIssuesByCondition(MultiValueMap<String, String> conditionMap, PageRequest pageRequest);
 }

--- a/BE/src/main/java/team20/issuetracker/domain/issue/IssueRepositoryImpl.java
+++ b/BE/src/main/java/team20/issuetracker/domain/issue/IssueRepositoryImpl.java
@@ -16,9 +16,9 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.util.MultiValueMap;
 
 import java.util.List;
-import java.util.Map;
 
 import javax.persistence.EntityManager;
 
@@ -32,7 +32,7 @@ public class IssueRepositoryImpl implements IssueRepositoryCustom {
 
     // 정리
     @Override
-    public Page<Issue> findAllIssuesByCondition(Map<String, String> conditionMap, PageRequest pageRequest) {
+    public Page<Issue> findAllIssuesByCondition(MultiValueMap<String, String> conditionMap, PageRequest pageRequest) {
         QIssue issueSub = new QIssue("issueSub");
 
         List<Issue> findAllIssues = queryFactory
@@ -113,54 +113,54 @@ public class IssueRepositoryImpl implements IssueRepositoryCustom {
 //        }
     }
 
-    private BooleanExpression statusEq(Map<String, String> conditionMap) {
+    private BooleanExpression statusEq(MultiValueMap<String, String> conditionMap) {
         return conditionMap.get("is") != null ? issue.status.eq(
-                IssueStatus.valueOf(conditionMap.get("is").toUpperCase())
+                IssueStatus.valueOf(conditionMap.get("is").get(0).toUpperCase())
         ) : null;
     }
 
-    private BooleanExpression milestoneEq(Map<String, String> conditionMap) {
+    private BooleanExpression milestoneEq(MultiValueMap<String, String> conditionMap) {
         return conditionMap.get("milestone") != null ? issue.milestone.title.eq(
-                conditionMap.get("milestone")
+                conditionMap.get("milestone").get(0)
         ) : null;
     }
 
-    private BooleanExpression authorEq(Map<String, String> conditionMap) {
+    private BooleanExpression authorEq(MultiValueMap<String, String> conditionMap) {
         return conditionMap.get("author") != null ? member.name.eq(
-                conditionMap.get("author")
+                conditionMap.get("author").get(0)
         ) : null;
     }
 
-    private BooleanExpression labelEq(Map<String, String> conditionMap, QIssue issueSub) {
+    private BooleanExpression labelEq(MultiValueMap<String, String> conditionMap, QIssue issueSub) {
         return conditionMap.get("label") != null ? issue.id.in(
                 select(issueSub.id)
                         .from(issueSub)
                         .innerJoin(issueLabel).on(issueLabel.issue.id.eq(issueSub.id))
                         .innerJoin(label).on(issueLabel.label.id.eq(label.id))
-                        .where(label.title.eq(conditionMap.get("label")))
+                        .where(label.title.in(conditionMap.get("label")))
         ) : null;
     }
 
-    private BooleanExpression assigneeEq(Map<String, String> conditionMap, QIssue issueSub) {
+    private BooleanExpression assigneeEq(MultiValueMap<String, String> conditionMap, QIssue issueSub) {
         return conditionMap.get("assignee") != null ? issue.id.in(
                 select(issueSub.id)
                         .from(issueSub)
                         .innerJoin(issueAssignee).on(issueAssignee.issue.id.eq(issueSub.id))
                         .innerJoin(assignee).on(issueAssignee.assignee.id.eq(assignee.id))
-                        .where(assignee.userId.eq(conditionMap.get("assignee")))
+                        .where(assignee.userId.in(conditionMap.get("assignee")))
         ) : null;
     }
 
-    private BooleanExpression commentedEq(Map<String, String> conditionMap, QIssue issueSub) {
+    private BooleanExpression commentedEq(MultiValueMap<String, String> conditionMap, QIssue issueSub) {
         return conditionMap.get("commented") != null ? issue.id.in(
                 select(issueSub.id)
                         .from(issueSub)
                         .innerJoin(comment).on(issueSub.id.eq(comment.issue.id))
-                        .where(comment.author.eq(conditionMap.get("commented")))
+                        .where(comment.author.in(conditionMap.get("commented")))
         ) : null;
     }
 
-    private Long countQuery(Map<String, String> conditionMap) {
+    private Long countQuery(MultiValueMap<String, String> conditionMap) {
         Long count = queryFactory.
                 select(issue.count())
                 .from(issue)

--- a/BE/src/main/java/team20/issuetracker/service/IssueService.java
+++ b/BE/src/main/java/team20/issuetracker/service/IssueService.java
@@ -5,16 +5,16 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import javax.validation.Valid;
 
 import lombok.RequiredArgsConstructor;
-
 import team20.issuetracker.domain.assginee.Assignee;
 import team20.issuetracker.domain.assginee.AssigneeRepository;
 import team20.issuetracker.domain.issue.Issue;
@@ -75,18 +75,18 @@ public class IssueService {
 
     @Transactional(readOnly = true)
     public ResponseReadAllIssueDto findAllIssuesByCondition(String condition, PageRequest pageRequest) {
-        Map<String, String> conditionMap = new HashMap<>();
+        MultiValueMap<String, String> conditionMap = new LinkedMultiValueMap<>();
         String[] conditionSplit = condition.split("\\|\\^&");
 
         for (int i = 0; i < conditionSplit.length; i++) {
             String key = conditionSplit[i].split(":")[0];
             String value = conditionSplit[i].split(":")[1];
-            conditionMap.put(key, value);
+            conditionMap.add(key, value);
         }
 
         Page<Issue> allIssuesByCondition = issueRepository.findAllIssuesByCondition(conditionMap, pageRequest);
         Page<ResponseIssueDto> responseIssueDtos = allIssuesByCondition.map(ResponseIssueDto::of);
-        Map<IssueStatus, Long> count = countByIssueStatusCheck(allIssuesByCondition, IssueStatus.valueOf(conditionMap.get("is").toUpperCase()));
+        Map<IssueStatus, Long> count = countByIssueStatusCheck(allIssuesByCondition, IssueStatus.valueOf(conditionMap.get("is").get(0).toUpperCase()));
 
         return ResponseReadAllIssueDto.of(count.get(IssueStatus.OPEN),count.get(IssueStatus.CLOSED), responseIssueDtos);
     }


### PR DESCRIPTION
Description
- 레이블과 같이 하나 이상의 값이 붙어있는 이슈를 필터링 할때 마지막 값만 필터에 적용되는 문제 수정
- 여러개의 레이블을 검색이 가능하게 변경되었지만, 두개 이상의 레이블 조건을 검색하였을때 두개의 레이블을 포함한 이슈가 조회 되는것이 아니라 각각의 레이블이 포함되어 있는 이슈가 조회되는 문제가 있다.