### PR TITLE
[geombong/issue-tracker#236] Fix Pagination API

### DIFF
--- a/BE/src/main/java/team20/issuetracker/domain/issue/IssueRepository.java
+++ b/BE/src/main/java/team20/issuetracker/domain/issue/IssueRepository.java
@@ -9,9 +9,6 @@ import java.util.List;
 
 public interface IssueRepository extends JpaRepository<Issue, Long>, IssueRepositoryCustom {
 
-    @Query("select count(i) from Issue i")
-    long findByIssueCount();
-
     @Modifying(clearAutomatically = true)
     @Query("update Issue i set i.milestone = null where i.milestone.id = :id")
     void deleteMilestone(@Param("id") Long id);

--- a/BE/src/main/java/team20/issuetracker/domain/issue/IssueRepositoryCustom.java
+++ b/BE/src/main/java/team20/issuetracker/domain/issue/IssueRepositoryCustom.java
@@ -7,4 +7,8 @@ import org.springframework.util.MultiValueMap;
 public interface IssueRepositoryCustom {
 
     Page<Issue> findAllIssuesByCondition(MultiValueMap<String, String> conditionMap, PageRequest pageRequest);
+
+    Long countQueryByIssueStatus(MultiValueMap<String, String> conditionMap);
+
+    Long allIssueCountQuery(MultiValueMap<String, String> conditionMap);
 }


### PR DESCRIPTION
## description
- 필터링을 거친 후 Open, Closed 된 이슈 갯수에 따라 페이지가 나오는 버그 발생
- 필터링 후 Issue 개수를 조정해 전체적인 이슈 갯수에 따라 페이지가 나오지 않도록 수정 예정
- 사용하지 않는 IssueRepository 의 findByIssueCount() 삭제
- 전체 Issue 갯수를 세는 allIssueCountQuery(), Issue Status 에 따라 Issue 갯수를 세는 countQueryByIssueStatus() 새로 작성