### PR TITLE
[geombong/issue-tracker#256] Fix Issue Service updateIssueRelated()

### DIFF
--- a/BE/src/main/java/team20/issuetracker/exception/CheckUpdateTypeException.java
+++ b/BE/src/main/java/team20/issuetracker/exception/CheckUpdateTypeException.java
@@ -1,0 +1,19 @@
+package team20.issuetracker.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public class CheckUpdateTypeException extends RuntimeException {
+
+    private final String errorMessage;
+    private final HttpStatus httpStatus;
+
+    @Override
+    public String getMessage() {
+        return errorMessage;
+    }
+}

--- a/BE/src/main/java/team20/issuetracker/exceptionhandler/GlobalExceptionHandler.java
+++ b/BE/src/main/java/team20/issuetracker/exceptionhandler/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.util.HashMap;
 import java.util.Map;
 
+import team20.issuetracker.exception.CheckUpdateTypeException;
 import team20.issuetracker.exception.MyJwtException;
 import team20.issuetracker.exception.CheckEntityException;
 
@@ -48,5 +49,13 @@ public class GlobalExceptionHandler {
         log.error("errorMessage : {}", checkEntityException.getErrorMessage());
 
         return new ResponseEntity<>(ResponseErrorMassage.create(checkEntityException.getErrorMessage()), checkEntityException.getHttpStatus());
+    }
+
+    @ExceptionHandler(CheckUpdateTypeException.class)
+    public ResponseEntity<ResponseErrorMassage> CheckUpdateTypeException(CheckUpdateTypeException checkUpdateTypeException) {
+
+        log.error("errorMessage : {}", checkUpdateTypeException.getErrorMessage());
+
+        return new ResponseEntity<>(ResponseErrorMassage.create(checkUpdateTypeException.getErrorMessage()), checkUpdateTypeException.getHttpStatus());
     }
 }

--- a/BE/src/main/java/team20/issuetracker/service/IssueService.java
+++ b/BE/src/main/java/team20/issuetracker/service/IssueService.java
@@ -141,7 +141,7 @@ public class IssueService {
 
     @Transactional
     public Long updateIssueRelated(Long id, String type, RequestUpdateIssueRelatedDto requestUpdateIssueRelatedDto) {
-        UpdateType updateType = UpdateType.valueOf(type.toUpperCase());
+        UpdateType updateType = UpdateType.checkUpdateType(type.toUpperCase());
         Issue findIssue = issueRepository.findById(id)
             .orElseThrow(() -> new CheckEntityException("해당 Issue 는 존재하지 않습니다.", HttpStatus.BAD_REQUEST));
 

--- a/BE/src/main/java/team20/issuetracker/service/RelatedUpdateFactory.java
+++ b/BE/src/main/java/team20/issuetracker/service/RelatedUpdateFactory.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 import team20.issuetracker.domain.assginee.AssigneeRepository;
 import team20.issuetracker.domain.label.LabelRepository;
 import team20.issuetracker.domain.milestone.MilestoneRepository;
-import team20.issuetracker.exception.CheckEntityException;
+import team20.issuetracker.exception.CheckUpdateTypeException;
 
 public interface RelatedUpdateFactory {
     RelatedUpdatable getRelatedType(UpdateType updateType);
@@ -20,17 +20,17 @@ class SimpleRelatedUpdateFactory implements RelatedUpdateFactory {
 
     @Override
     public RelatedUpdatable getRelatedType(UpdateType updateType) {
-        if (updateType.equals(UpdateType.MILESTONE)) {
-            return new RelatedMilestone(milestoneRepository);
+        switch(updateType) {
+            case MILESTONE:
+                return new RelatedMilestone(milestoneRepository);
 
-        } else if (updateType.equals(UpdateType.LABELS)) {
-            return new RelatedLabel(labelRepository);
+            case LABELS:
+                return new RelatedLabel(labelRepository);
 
-        } else if (updateType.equals(UpdateType.ASSIGNEES)) {
-            return new RelatedAssignee(assigneeRepository);
-
-        } else {
-            throw new CheckEntityException("해당 UpdateType 은 존재하지 않습니다.", HttpStatus.BAD_REQUEST);
+            case ASSIGNEES:
+                return new RelatedAssignee(assigneeRepository);
         }
+
+        throw new CheckUpdateTypeException("해당 UpdateType 은 존재하지 않습니다.", HttpStatus.BAD_REQUEST);
     }
 }

--- a/BE/src/main/java/team20/issuetracker/service/UpdateType.java
+++ b/BE/src/main/java/team20/issuetracker/service/UpdateType.java
@@ -2,6 +2,10 @@ package team20.issuetracker.service;
 
 import lombok.Getter;
 
+import org.springframework.http.HttpStatus;
+
+import team20.issuetracker.exception.CheckUpdateTypeException;
+
 public enum UpdateType {
     MILESTONE("milestone"),
     LABELS("labels"),
@@ -12,5 +16,16 @@ public enum UpdateType {
 
     UpdateType(String type) {
         this.type = type;
+    }
+
+    public static UpdateType checkUpdateType(String updateType) {
+        UpdateType[] values = UpdateType.values();
+        for (UpdateType value : values) {
+            if (value.getType().equals(updateType.toUpperCase())) {
+                return value;
+            }
+        }
+
+        throw new CheckUpdateTypeException("해당 UpdateType 은 존재하지 않습니다.", HttpStatus.BAD_REQUEST);
     }
 }


### PR DESCRIPTION
## description
- [x] Issue Service 의 updateIssueRelated() 메서드에서 클라이언트로 받아오는 UpdateType 을 검증하는 로직 수정
- [x] Enum 에서 제공하는 valueOf() 메서드가 아닌 checkUpdateType() 메서드를 새로 생성해서 따로 사용하도록 수정